### PR TITLE
Removed margin around the "fork me" link

### DIFF
--- a/demo.css
+++ b/demo.css
@@ -1,4 +1,5 @@
 body {
+    margin: 0;
     text-align: center;
     font-family: 'Palatino Linotype';
     font-size: 24px;


### PR DESCRIPTION
Although the image is absolutely positioned to top=0/right=0, the body still has some default margin  that was preventing it from truly snapping to the corner.