### PR TITLE
Just use "search-index-min" and don't bother with "search-index-head".

### DIFF
--- a/assets/script/search.ts
+++ b/assets/script/search.ts
@@ -31,10 +31,8 @@ function typeSearch(el: HTMLInputElement) {
 		minLength: 0
 	};
 
-	const source = createDataSource();
-
 	const data = {
-		source,
+		source: createDataSource(),
 		displayKey: 't',
 		templates: {
 			suggestion: (obj: MinifiedSearchRecord) => {
@@ -47,10 +45,11 @@ function typeSearch(el: HTMLInputElement) {
 	};
 
 	jqueryEl.typeahead(opts, data);
-	jqueryEl.on('typeahead:select', (unused: {}, obj: MinifiedSearchRecord) => navigate(obj.t));
+	jqueryEl.on('typeahead:select', (unused: {}, obj: MinifiedSearchRecord) => navigate(obj));
 	jqueryEl.keyup(k => {
-		if(k.keyCode === 13) {
-			navigate(el.value);
+		if (k.keyCode === 13) { // Enter key
+			const selectables = jqueryEl.siblings(".tt-menu").find(".tt-selectable");
+			$(selectables[0]).trigger("click");
 		}
 	});
 
@@ -58,16 +57,12 @@ function typeSearch(el: HTMLInputElement) {
 		ai.trackEvent('focus');
 	});
 
-	function navigate(value: string) {
+	function navigate(record: MinifiedSearchRecord) {
 		if (ai) {
-			ai.trackEvent('navigate', { target: value });
+			ai.trackEvent('navigate', { target: record.t });
 		}
-		// Navigate only if the selected string is a valid package, else return.
-		const result = source.local.some((e: MinifiedSearchRecord) => e.t === value);
-		if (!result) {
-			return;
-		}
-		window.location.href = `https://www.npmjs.org/package/@types/${value}`;
+
+		window.location.href = `https://www.npmjs.org/package/@types/${record.t}`;
 	}
 
 	function createDataSource(): Bloodhound<MinifiedSearchRecord> {


### PR DESCRIPTION
Verified in Chrome debugger that we are getting cached results in subsequent page loads.
Initial (uncached) load of search-index-min.js takes 1.3s, 400ms of which is waiting.

**Update**: using blobs from Microsoft/types-publisher#86, the times are:

| Action | Time |
| --- | --- |
| Request sent | 0.27ms |
| Waiting (TTFB) | 503ms  |
| Content Download | 199.73ms |

(+ 315ms for the initial connection)
