### PR TITLE
Hooked up search inputs to URL 'search' query param

### DIFF
--- a/assets/static/index.html
+++ b/assets/static/index.html
@@ -8,13 +8,6 @@
     <script src="lib/jquery.min.js"></script>
     <script src="lib/typeahead.bundle.min.js"></script>
     <script src="script/search.js"></script>
-    <script>
-    	$(function() {
-        var el = document.getElementById('demo');
-        typeSearch(el);
-        $(el).focus();
-    	});
-    </script>
   </head>
   <body>
     <h1><span class="typescript"><span class="bold">Type</span>Search</span></h1>


### PR DESCRIPTION
Fixes #31. Two behavior changes are included here:

* If there exists a `search` param when the page is loaded, the input has that set as its typeahead value and is opened immediateely
* Input changes add or update the same `search` query param
